### PR TITLE
electron cmd cross platform fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function floss(options, done) {
         // options.electron will just be "electron" at this point.
         // Due to limitations with how nodejs spawns windows processes we need to add .cmd to the end of the command
         // https://github.com/nodejs/node/issues/3675
-        options.electron = options.electron + ".cmd";
+        options.electron += ".cmd";
     }
 
     const childProcess = spawn(

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ function floss(options, done) {
     const app = path.join(__dirname, 'electron');
     const args = JSON.stringify(options);
 
-    let isWindows = /^win/.test(process.platform);
-    if(isWindows  && !path.extname(options.electron)) {
+    const isWindows = /^win/.test(process.platform);
+    if(isWindows && !path.extname(options.electron)) {
         // In the case where floss is running in windows with the cmdline option --electron electron
         // options.electron will just be "electron" at this point.
         // Due to limitations with how nodejs spawns windows processes we need to add .cmd to the end of the command


### PR DESCRIPTION
### Fixed
* cross platform fix for passing `--electron electron` command in windows