### PR TITLE
Adds the ability to specify a different reporter for mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ floss --path test/index.js --debug
 
 ### Reporter
 
-Can use the same reporter options as the API mentioned above.
+Can use the same reporter options as the API mentioned above. The `reporter-options` are expressed as a querystring, for instance `varname=foo&another=bar`.
 
 ```bash
 floss --path test/index.js \

--- a/README.md
+++ b/README.md
@@ -34,27 +34,35 @@ gulp.task('test', function(done) {
 Open tests in an Electron window where test can can be debugged with `debugger` and dev tools.
 
 ```js
-const floss = require('floss');
-gulp.task('test', function(done) {
-    floss({
-        path: 'test/index.js',
-        debug: true
-    }, done);
-});
+floss({
+    path: 'test/index.js',
+    debug: true
+}, done);
 ```
 
-### Additional Options
+### Mocha Reporter
+
+The `reporter` and `reporterOptions` are pass-through options for Mocha to specify a different reporter when running Floss in non-debug mode.
+
+```js
+floss({
+    path: 'test/index.js',
+    reporter: 'xunit',
+    reporterOptions: {
+    	filename: 'report.xml'
+    }
+}, done);
+```
+
+### Custom Options
 
 Additional properties can be passed to the test code by adding more values to the run options.
 
 ```js
-const floss = require('floss');
-gulp.task('test', function(done) {
-    floss({
-        path: 'test/index.js',
-        customUrl: 'http://localhost:8080' // <- custom
-    }, done);
-});
+floss({
+    path: 'test/index.js',
+    customUrl: 'http://localhost:8080' // <- custom
+}, done);
 ```
 
 The test code and use the global `options` property to have access to the run options.
@@ -93,6 +101,16 @@ Open tests in an Electron window where test can can be debugged with `debugger` 
 
 ```bash
 floss --path test/index.js --debug
+```
+
+### Reporter
+
+Can use the same reporter options as the API mentioned above.
+
+```bash
+floss --path test/index.js \
+    --reporter=xunit \
+    --reporter-options output=report.xml
 ```
 
 ## Custom Electron Version

--- a/bin/floss.js
+++ b/bin/floss.js
@@ -29,7 +29,7 @@ function parseArgs(args) {
         .option('-p, --path [path/to/folder/or/file.js]', 'Either a path to a directory containing index.js or a path to a single test file')
         .option('-e, --electron [path/to/Electron]', 'Path to version of Electron to test on')
         .option('-r, --reporter [spec]', 'Mocha reporter for headless mode only')
-        .option('-r, --reporter-options [spec]', 'Additional arguments for reporter options, query-string formatted, e.g., "filename=report.xml"')
+        .option('-r, --reporter-options [filename=report.xml]', 'Additional arguments for reporter options, query-string formatted')
         .parse(args);
     return commander;
 }

--- a/bin/floss.js
+++ b/bin/floss.js
@@ -29,7 +29,7 @@ function parseArgs(args) {
         .option('-p, --path [path/to/folder/or/file.js]', 'Either a path to a directory containing index.js or a path to a single test file')
         .option('-e, --electron [path/to/Electron]', 'Path to version of Electron to test on')
         .option('-r, --reporter [spec]', 'Mocha reporter for headless mode only')
-        .option('-r, --reporter-options [spec]', 'Additional arguments for reporter options')
+        .option('-r, --reporter-options [spec]', 'Additional arguments for reporter options, query-string formatted, e.g., "filename=report.xml"')
         .parse(args);
     return commander;
 }

--- a/bin/floss.js
+++ b/bin/floss.js
@@ -29,7 +29,7 @@ function parseArgs(args) {
         .option('-p, --path [path/to/folder/or/file.js]', 'Either a path to a directory containing index.js or a path to a single test file')
         .option('-e, --electron [path/to/Electron]', 'Path to version of Electron to test on')
         .option('-r, --reporter [spec]', 'Mocha reporter for headless mode only')
-        .option('-r, --reporter-options [filename=report.xml]', 'Additional arguments for reporter options, query-string formatted')
+        .option('-o, --reporter-options [filename=report.xml]', 'Additional arguments for reporter options, query-string formatted')
         .parse(args);
     return commander;
 }

--- a/bin/floss.js
+++ b/bin/floss.js
@@ -28,6 +28,8 @@ function parseArgs(args) {
     commander.option('-d, --debug', 'Launch electron in debug mode')
         .option('-p, --path [path/to/folder/or/file.js]', 'Either a path to a directory containing index.js or a path to a single test file')
         .option('-e, --electron [path/to/Electron]', 'Path to version of Electron to test on')
+        .option('-r, --reporter [spec]', 'Mocha reporter for headless mode only')
+        .option('-r, --reporter-options [spec]', 'Additional arguments for reporter options')
         .parse(args);
     return commander;
 }

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -58,7 +58,7 @@ class Renderer {
         try {
             this.redirectOutputToConsole();
             mocha.setup({
-                ui: 'tdd',
+                ui: 'tdd'
             });
 
             // Format the reporter options

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ catch(err) {
  * @param {String} [options.electron] Path to custom electron version. If undefined
  *        will use environment variable `ELECTRON_PATH` or electron-prebuilt
  *        installed alongside.
+ * @param {String} [options.reporter=spec] Mocha reporter (non-debug mode only)
+ * @param {String} [options.reporterOptions] Additional options for the reporter
+ *        useful for specifying an output file if using the 'xunit' reporter.
  * @param {Function} done Called when completed. Passes error if failed.
  */
 function floss(options, done) {

--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ catch(err) {
  *        will use environment variable `ELECTRON_PATH` or electron-prebuilt
  *        installed alongside.
  * @param {String} [options.reporter=spec] Mocha reporter (non-debug mode only)
- * @param {String} [options.reporterOptions] Additional options for the reporter
+ * @param {String|Object} [options.reporterOptions] Additional options for the reporter
  *        useful for specifying an output file if using the 'xunit' reporter.
- *        Options are a querystring format, e.g., `"foo=2&bar=something"`
+ *        Options can be a querystring format, e.g., `"foo=2&bar=something"`
  * @param {Function} done Called when completed. Passes error if failed.
  */
 function floss(options, done) {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ catch(err) {
  * @param {String} [options.reporter=spec] Mocha reporter (non-debug mode only)
  * @param {String} [options.reporterOptions] Additional options for the reporter
  *        useful for specifying an output file if using the 'xunit' reporter.
+ *        Options are a querystring format, e.g., `"foo=2&bar=something"`
  * @param {Function} done Called when completed. Passes error if failed.
  */
 function floss(options, done) {


### PR DESCRIPTION
### Adds

* Adds the ability to use a different reporter (e.g. `xunit`) with Floss, this can be used with CI to generate browsable reports of the tests that passed or failed.

### Fixed

* Fixes an issue with creating too many new-lines when output the results from Mocha in non-debug mode (headless).