### PR TITLE
Console log a summary instead of text-summary (with ANSI colors)

### DIFF
--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -38,7 +38,9 @@ class Renderer {
                     root,
                     response.coveragePattern,
                     response.coverageSourceMaps,
-                    response.coverageHtmlReporter);
+                    response.coverageHtmlReporter,
+                    response.debug
+                );
             }
             if (response.debug) {
                 this.headful(response.path);


### PR DESCRIPTION
### Added

* Creates an ANSI-less summary when running coverage in debug mode.

#### Preview

![screen shot 2016-10-05 at 2 27 47 pm](https://cloud.githubusercontent.com/assets/864393/19126232/0bc254c6-8b08-11e6-8697-340b5c14d82c.png)
