### PR TITLE
Strip ANSI colors from the console.log in debug mode

### DIFF
--- a/electron/coverage.js
+++ b/electron/coverage.js
@@ -52,6 +52,7 @@ class Coverage {
      */
     stopCleanLogs() {
         console.log = console._originalLog;
+        delete console._originalLog;
     }
 
     /**

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -38,7 +38,9 @@ class Renderer {
                     root,
                     response.coveragePattern,
                     response.coverageSourceMaps,
-                    response.coverageHtmlReporter);
+                    response.coverageHtmlReporter,
+                    response.debug
+                );
             }
             if (response.debug) {
                 this.headful(response.path);

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "remap-istanbul": "^0.6.4",
     "resolve": "^1.1.7",
     "sinon": "^1.17.4",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "strip-ansi": "^3.0.1"
   },
   "peerDependencies": {
     "electron-prebuilt": "^1.0.0"


### PR DESCRIPTION
### Fixed

* Simpler approach to strip ANSI colors from the `console.log` when in debug mode.

Replaces #7 