### PR TITLE
Parse List function should always split

### DIFF
--- a/bin/floss.js
+++ b/bin/floss.js
@@ -29,9 +29,6 @@ function cli(args, callback) {
  * Split the value by comma or spaces
  */
 function parseList(value) {
-    if(typeof value === 'string') {
-        return [value];
-    }
     return value.split(/[\s,]\s*/);
 }
 


### PR DESCRIPTION
Fixes a bug where `--coveragePattern "./lib/**/*.js, ./src/**/*.js"` will not read in those files.