### PR TITLE
Override environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ function floss(options, done) {
 
     const childProcess = spawn(
         options.electron, [app, args], {
-            stdio: 'inherit'
+            stdio: 'inherit',
+            env: {}
         }
     );
     childProcess.on('close', (code) => {

--- a/index.js
+++ b/index.js
@@ -62,10 +62,14 @@ function floss(options, done) {
         options.electron += ".cmd";
     }
 
+    //copy the environment and remove things that would prevent Floss from running properly
+    const envCopy = Object.assign({}, process.env);
+    delete envCopy.ELECTRON_RUN_AS_NODE;
+    delete envCopy.ELECTRON_NO_ATTACH_CONSOLE;
     const childProcess = spawn(
         options.electron, [app, args], {
             stdio: 'inherit',
-            env: {}
+            env: envCopy
         }
     );
     childProcess.on('close', (code) => {


### PR DESCRIPTION
Atom's buffered-node-process inserts environment variables that interfere with Electron, so if you try to run Floss from a terminal spawned by Atom, Floss fails to work. By overriding `env`, Floss runs the way it should, and does not seem to have any problems resulting from having no environment variables.