### PR TITLE
Deprecate electron-prebuilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Uses Electron to provide a Mocha unit-testing environment which can be run headl
 Install globally:
 
 ```bash
-npm install -g floss electron-prebuilt
+npm install -g floss electron
 ```
 
 Install locally within a project:
 
 ```bash
-npm install floss electron-prebuilt --save-dev
+npm install floss electron --save-dev
 ```
 
 ## Gulp Usage
@@ -172,7 +172,7 @@ Some application may require a specific version of Electron. Floss uses Electron
 gulp.task('test', function(done) {
     floss({
         path: 'test/index.js',
-        electron: require('electron-prebuilt')
+        electron: require('electron')
     }, done);
 });
 ```

--- a/index.js
+++ b/index.js
@@ -68,13 +68,10 @@ function floss(options, done) {
     delete envCopy.ELECTRON_NO_ATTACH_CONSOLE;
     const childProcess = spawn(
         options.electron, [app, args], {
-            stdio: 'pipe',
+            stdio: 'inherit',
             env: envCopy
         }
     );
-    childProcess.stdout.on('data', (data) => {
-        process.stdout.write(data);
-    });
     childProcess.on('close', (code) => {
         if (code !== 0) {
             return done(new Error('Mocha tests failed'));

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const spawn = require('child_process').spawn;
 
 let electron;
 try {
-    electron = require('electron-prebuilt');
+    electron = require('electron');
 }
 catch(err) {
     // silence is golden
@@ -19,7 +19,7 @@ catch(err) {
  * @param {String} [options.path] Path to the JS file to run.
  * @param {Boolean} [options.debug] `true` opens in headful mode.
  * @param {String} [options.electron] Path to custom electron version. If undefined
- *        will use environment variable `ELECTRON_PATH` or electron-prebuilt
+ *        will use environment variable `ELECTRON_PATH` or electron
  *        installed alongside.
  * @param {String} [options.reporter=spec] Mocha reporter (non-debug mode only)
  * @param {String|Object} [options.reporterOptions] Additional options for the reporter
@@ -46,7 +46,7 @@ function floss(options, done) {
     }
 
     if (!options.electron) {
-        console.error("Error: Unable to find Electron. Install 'electron-prebuilt' alongside Floss.".red);
+        console.error("Error: Unable to find Electron. Install 'electron' alongside Floss.".red);
         return done();
     }
 
@@ -68,10 +68,13 @@ function floss(options, done) {
     delete envCopy.ELECTRON_NO_ATTACH_CONSOLE;
     const childProcess = spawn(
         options.electron, [app, args], {
-            stdio: 'inherit',
+            stdio: 'pipe',
             env: envCopy
         }
     );
+    childProcess.stdout.on('data', (data) => {
+        process.stdout.write(data);
+    });
     childProcess.on('close', (code) => {
         if (code !== 0) {
             return done(new Error('Mocha tests failed'));

--- a/package.json
+++ b/package.json
@@ -64,10 +64,11 @@
     "strip-ansi": "^3.0.1"
   },
   "peerDependencies": {
-    "electron-prebuilt": "^1.0.0"
+    "electron": "^1.4.15"
   },
   "devDependencies": {
-    "eslint": "^3.5.0"
+    "eslint": "^3.5.0",
+    "electron": "^1.4.15"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",


### PR DESCRIPTION
### Changed

* Deprecates support for **electron-prebuilt** and replaces with the new offical **electron** package. This is a breaking change because of the inability of NPM peerDependencies to support both the current and deprecated package. 

**Note: This is a breaking change and requires a major bump**
