### PR TITLE
Optionally send all logs to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ console.log(options.customUrl); // logs: http://localhost:8080
 
 * **--path** or **-p** (String) Path to the file to test
 * **--debug** or **-d**  (Boolean) Enable to run in headful mode, default `false`.
+* **--quiet** or **-q** (Boolean) Prevent console[log/info/error/warn/dir] messages from appearing in `stdout`.
 * **--electron** or **-e**  (String) Path to the electron to use.
 * **--reporter** or **-r**  (String) Mocha reporter type, default `spec`.
 * **--reporterOptions** or **-o**  (String) Mocha reporter options.

--- a/bin/floss.js
+++ b/bin/floss.js
@@ -7,10 +7,6 @@ const floss = require('../');
 require('colors');
 
 function cli(args, callback) {
-    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
-    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
-    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
-    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
     const parsedArgs = parseArgs(args);
     // console.log(parsedArgs.coveragePattern);
     if (!parsedArgs.path) {

--- a/bin/floss.js
+++ b/bin/floss.js
@@ -7,6 +7,10 @@ const floss = require('../');
 require('colors');
 
 function cli(args, callback) {
+    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
+    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
+    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
+    console.log("THAGBERG THAGBERG THAGBERG THAGBERG");
     const parsedArgs = parseArgs(args);
     // console.log(parsedArgs.coveragePattern);
     if (!parsedArgs.path) {
@@ -41,6 +45,7 @@ function parseArgs(args) {
         .option('-h, --coverageHtmlReporter', 'Also generate an html report')
         .option('-r, --reporter [spec]', 'Mocha reporter for headless mode only')
         .option('-o, --reporterOptions [filename=report.xml]', 'Additional arguments for reporter options, query-string formatted')
+        .option('-q, --quiet', 'Prevent console.(log/info/error/warn) messages from appearing in STDOUT')
         .parse(args);
     return commander;
 }

--- a/electron/index.js
+++ b/electron/index.js
@@ -40,15 +40,13 @@ function createWindow() {
 
     options.show = args.debug;
 
-    if (!args.quiet) {
+    // Create handlers for piping rendered logs to console
+    if (!args.debug && !args.quiet) {
         for (let name in console) {
-            ipcMain.on(name, function(...args) {
-                args.shift();
+            ipcMain.on(name, function(event, args) {
                 console[name](...args);
             })
         }
-    } else {
-        console.log("QUIET IS ON");
     }
 
 

--- a/electron/index.js
+++ b/electron/index.js
@@ -40,6 +40,18 @@ function createWindow() {
 
     options.show = args.debug;
 
+    if (!args.quiet) {
+        for (let name in console) {
+            ipcMain.on(name, function(...args) {
+                args.shift();
+                console[name](...args);
+            })
+        }
+    } else {
+        console.log("QUIET IS ON");
+    }
+
+
     // Create the browser window.
     mainWindow = new BrowserWindow(options);
 
@@ -57,7 +69,7 @@ function createWindow() {
     // don't show the dev tools if you're not in headless mode. this is to
     // avoid having breakpoints and "pause on caught / uncaught exceptions" halting
     // the runtime.  plus, if you're in headless mode, having the devtools open is probably
-    // not very useful anyway 
+    // not very useful anyway
     if(args.debug) {
         // Open the DevTools.
         mainWindow.webContents.openDevTools('bottom');

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -21,6 +21,8 @@ global.assert = chai.assert;
 global.expect = chai.expect;
 global.chai.use(sinonChai);
 
+let globalLoggers = {};
+
 class Renderer {
 
     constructor(linkId) {
@@ -53,6 +55,17 @@ class Renderer {
         const mochaPath = path.dirname(resolve.sync('mocha', {basedir: __dirname}));
         const link = document.getElementById(linkId);
         link.href = path.join(mochaPath, 'mocha.css');
+
+        if (!this.options.quiet) {
+            for (let name in console) {
+                globalLoggers[name] = console[name];
+                console[name] = function(...args) {
+                    ipcRenderer.send(name, ...args);
+                }
+            }
+        } else {
+            alert("QUIET IS ON");
+        }
     }
 
     headful(testPath) {
@@ -74,6 +87,8 @@ class Renderer {
     }
 
     headless(testPath) {
+        console.log("PUT THIS IN STDOUT", {test: "one", blah: "three"});
+        console.error("PUT THIS IN STDERR");
         try {
             this.redirectOutputToConsole();
             mocha.setup({

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function floss(options, done) {
 
     options = assign({
         debug: false,
+        quiet: false,
         electron: process.env.ELECTRON_PATH || electron
     }, options);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floss",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Unit-testing for those hard to reach places",
   "bin": "./bin/floss.js",
   "main": "./index.js",


### PR DESCRIPTION

By default, will send all logs originating within the render process to `stdout`.  Otherwise, these logs were only visible within devTools when running in debug mode.

Adds a `-q / --quiet` command-line option, which will silence these extra logs.