### PR TITLE
v2.1.2 hotfix for publish error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floss",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Unit-testing for those hard to reach places",
   "bin": "./bin/floss.js",
   "main": "./index.js",


### PR DESCRIPTION
*Fixes*
 - My bad I was having all sorts of npm issues around auth and publishing too early in the morning, made the mistake of publishing the v1 branch without using `--tag legacy`. I did a patch bump and published a `2.1.2` to rectify this.
![screen shot 2017-05-27 at 6 30 08 am](https://cloud.githubusercontent.com/assets/1845/26520733/2cc22d62-42a6-11e7-9cab-563077f2ebb9.png)
