### PR TITLE
prevent infinite loop when logging objects to stdout

### DIFF
--- a/bin/floss.js
+++ b/bin/floss.js
@@ -42,6 +42,8 @@ function parseArgs(args) {
         .option('-r, --reporter [spec]', 'Mocha reporter for headless mode only')
         .option('-o, --reporterOptions [filename=report.xml]', 'Additional arguments for reporter options, query-string formatted')
         .option('-q, --quiet', 'Prevent console.(log/info/error/warn) messages from appearing in STDOUT')
+        .option('-l, --logdepth [int]', 'When logging complex objects we truncate convert the complex object to a string truncated to a default depth of 3. This property allows to override that.')
+
         .parse(args);
     return commander;
 }

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -10,6 +10,7 @@ const resolve = require('resolve');
 const {ipcRenderer, remote} = require('electron');
 const Coverage = require('./coverage');
 const querystring = require('querystring');
+const util = require('util');
 
 require('mocha/mocha');
 require('chai/chai');
@@ -21,7 +22,9 @@ global.assert = chai.assert;
 global.expect = chai.expect;
 global.chai.use(sinonChai);
 
+const defaultLogDepth = 3;
 const globalLoggers = {};
+
 
 class Renderer {
 
@@ -45,6 +48,7 @@ class Renderer {
                     response.debug
                 );
             }
+            this.logDepth = response.logdepth || defaultLogDepth;
             if (response.debug) {
                 this.headful(response.path);
             } else {
@@ -131,30 +135,38 @@ class Renderer {
     }
 
     setupConsoleOutput(isQuiet, isHeadless) {
-        const remoteConsole = remote.getGlobal('console');
-
-        if (isQuiet) {
-            if (isHeadless) {
-                console.log = function() {
-                    remoteConsole.log.apply(remoteConsole, arguments)
-                }
-
-                console.dir = function() {
-                    remoteConsole.dir.apply(remoteConsole, arguments)
-                }
+        if (!isQuiet && isHeadless) {
+            const remoteConsole = remote.getGlobal('console');
+            
+            // we have to do this so that mocha output doesn't look like shit
+            console.log = function() {
+                let depthLimitArgs = Array.from(arguments).map((arg)=>{
+                    if(typeof arg === "object") {
+                        return util.inspect(arg, {depth: this.logDepth });                
+                    } else {
+                        return arg;
+                    }
+                });
+                remoteConsole.log.apply(remoteConsole, depthLimitArgs);
             }
-        } else if (isHeadless){
-            bindConsole();
+
+            console.dir = function() {
+                remoteConsole.dir.apply(remoteConsole, arguments);
+            }
+
+            // if we don't do this, we get socket errors and our tests crash
+            Object.defineProperty(process, 'stdout', {
+                value: {
+                    write: function(str) {
+                        let depthLimitStr = str;
+                        if(typeof depthLimitStr === "object") {
+                            depthLimitStr = util.inspect(depthLimitStr, {depth: this.logDepth });
+                        }
+                        remote.process.stdout.write(depthLimitStr);
+                    }
+                }
+            });
         }
-
-        // if we don't do this, we get socket errors and our tests crash
-        Object.defineProperty(process, 'stdout', {
-            value: {
-                write: function(str) {
-                    remote.process.stdout.write(str);
-                }
-            }
-        });
 
         // Create new bindings for `console` functions
         // Use default console[name] and also send IPC

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -23,8 +23,8 @@ global.expect = chai.expect;
 global.chai.use(sinonChai);
 
 const defaultLogDepth = 3;
-const globalLoggers = {};
-
+// TODO this needs to be reimplemented
+// const globalLoggers = {};
 
 class Renderer {
 
@@ -168,20 +168,21 @@ class Renderer {
             });
         }
 
-        // Create new bindings for `console` functions
-        // Use default console[name] and also send IPC
-        // log so we can log to stdout
-        function bindConsole() {
-            for (const name in console) {
-                if (typeof console[name] === 'function') {
-                    globalLoggers[name] = console[name];
-                    console[name] = function(...args) {
-                        globalLoggers[name].apply(console, args);
-                        ipcRenderer.send(name, args);
-                    }
-                }
-            }
-        }
+        // TODO this needs to be reimplemented
+        // // Create new bindings for `console` functions
+        // // Use default console[name] and also send IPC
+        // // log so we can log to stdout
+        // function bindConsole() {
+        //     for (const name in console) {
+        //         if (typeof console[name] === 'function') {
+        //             globalLoggers[name] = console[name];
+        //             console[name] = function(...args) {
+        //                 globalLoggers[name].apply(console, args);
+        //                 ipcRenderer.send(name, args);
+        //             }
+        //         }
+        //     }
+        // }
     }
 
     addFile(testPath, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floss",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Unit-testing for those hard to reach places",
   "bin": "./bin/floss.js",
   "main": "./index.js",

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,16 @@
 'use strict';
 
-describe('babys first test', ()=>{
-  it('should always be true - dummy test', function(){
-    expect(true).to.be.ok;
-  });
+describe('Floss Tests', ()=>{
+  describe("logging", function() {
+    it('should not hang when logging objects with circular references in headless mode', function(){
+      let foo = {        
+        get bar() {
+          return this.bar();
+        },
+      }
 
-  it('should evaluate to true', ()=>{
-    expect(false).to.not.be.ok;
+      console.log(foo);
+      process.stdout.write(foo);
+    });
   });
 });


### PR DESCRIPTION
### Changed
* parametrizing log depths of complex objects when turning them into a string when logging out to stdout